### PR TITLE
Add failing test case

### DIFF
--- a/block_formats.go
+++ b/block_formats.go
@@ -83,7 +83,6 @@ func (lf *listFormat) Open(open []*Format, o *Op) bool {
 
 // listFormat implements the FormatWrapper interface.
 func (lf *listFormat) Close(open []*Format, o *Op, doingBlock bool) bool {
-
 	if !doingBlock { // The closing wrap is written only when we know what kind of block this will be.
 		return false
 	}
@@ -99,13 +98,12 @@ func (lf *listFormat) Close(open []*Format, o *Op, doingBlock bool) bool {
 	//	return true
 	//}
 
-	//t := o.Attrs["list"]                   // The type of the current list item (ordered or bullet).
+	// t := o.Attrs["list"]                   // The type of the current list item (ordered or bullet).
 	// ind := indentDepths[o.Attrs["indent"]] // The indent of the current list item.
 
 	// Close the list block only if both (a) the current list item is staying at the same indent level or is at a
 	// lower indent level and (b) the type of the list is different from the type of the previous.
 	// return ind <= lf.indent && ((t == "ordered" && lf.lType != "ol") || (t == "bullet" && lf.lType != "ul"))
-
 }
 
 // indentDepths gives either the indent amount of a list or 0 if there is no indenting.

--- a/render.go
+++ b/render.go
@@ -24,7 +24,6 @@ func Render(ops []byte) ([]byte, error) {
 // customize the way certain kinds of inserts are rendered, and returns the rendered HTML. If the given Formatter is nil,
 // then the default one that is built in is used. If an error occurs while rendering, any HTML already rendered is returned.
 func RenderExtended(ops []byte, customFormats func(string, *Op) Formatter) ([]byte, error) {
-
 	raw := make([]rawOp, 0, 12)
 	if err := json.Unmarshal(ops, &raw); err != nil {
 		return nil, err
@@ -68,13 +67,10 @@ func RenderExtended(ops []byte, customFormats func(string, *Op) Formatter) ([]by
 
 				// If the current o.Data still has an "\n" following (its not the last in split), then it ends a block.
 				if j < len(split)-1 {
-
 					vars.o.writeBlock(&vars)
-
 				} else if vars.o.Data != "" { // If the last element in split is just "" then the last character in the rawOp is "\n".
 
 					vars.o.writeInline(&vars)
-
 				}
 
 			}
@@ -90,7 +86,6 @@ func RenderExtended(ops []byte, customFormats func(string, *Op) Formatter) ([]by
 	vars.fs.closePrevious(&vars.finalBuf, blankOp(), true)
 
 	return vars.finalBuf.Bytes(), nil
-
 }
 
 // renderVars combines the variables created in RenderExtended into a single allocation.
@@ -142,7 +137,6 @@ type Op struct {
 // The opening HTML tag of a block element is written to the main buffer only after the "\n" character terminating the
 // block is reached (the Op with the "\n" character holds the information about the block element).
 func (o *Op) writeBlock(vars *renderVars) {
-
 	// Close the inline formats opened within the block to the tempBuf and block formats of wrappers to finalBuf.
 	closedTemp := make(formatState, 0, 1)
 
@@ -234,12 +228,10 @@ func (o *Op) writeBlock(vars *renderVars) {
 	}
 
 	vars.tempBuf.Reset()
-
 }
 
 // writeInline writes to the temporary buffer.
 func (o *Op) writeInline(vars *renderVars) {
-
 	vars.fs.closePrevious(&vars.tempBuf, o, false)
 
 	// Save the formats being written now separately from fs.
@@ -264,7 +256,6 @@ func (o *Op) writeInline(vars *renderVars) {
 	vars.fs = append(vars.fs, addNow...) // Copy after the sorting.
 
 	vars.tempBuf.WriteString(o.Data)
-
 }
 
 // HasAttr says if the Op is not nil and has the attribute set to a non-blank value.
@@ -275,7 +266,6 @@ func (o *Op) HasAttr(attr string) bool {
 // getFormatter returns a formatter based on the keyword (either "text" or "" or an attribute name) and the Op settings.
 // For every Op, first its Type is passed through here as the keyword, and then its attributes.
 func (o *Op) getFormatter(keyword string, customFormats func(string, *Op) Formatter) Formatter {
-
 	if customFormats != nil {
 		if custom := customFormats(keyword, o); custom != nil {
 			return custom
@@ -348,7 +338,6 @@ func (o *Op) getFormatter(keyword string, customFormats func(string, *Op) Format
 	}
 
 	return nil
-
 }
 
 // A FormatPlace is either an HTML tag name, a CSS class, or a style attribute value.

--- a/render_test.go
+++ b/render_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestSimple(t *testing.T) {
-
 	cases := map[string]struct {
 		ops  string
 		want string
@@ -84,16 +83,13 @@ func TestSimple(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestRender(t *testing.T) {
-
-	pairNames := []string{"ops1", "nested", "ordering", "list1", "list2", "list3", "list4", "indent", "code1", "code2", "code3"}
+	pairNames := []string{"ops1", "nested", "ordering", "list1", "list2", "list3", "list4", "list5", "list6", "indent", "code1", "code2", "code3"}
 
 	for _, n := range pairNames {
 		t.Run(n, func(t *testing.T) {
-
 			ops, err := ioutil.ReadFile("./testdata/" + n + ".json")
 			if err != nil {
 				t.Fatalf("could not read %s.json; %s", n, err)
@@ -112,10 +108,8 @@ func TestRender(t *testing.T) {
 			if !bytes.Equal(html, got) {
 				t.Errorf("bad rendering:\nwanted: \n%s\ngot: \n%s", html, got)
 			}
-
 		})
 	}
-
 }
 
 func TestClassesList(t *testing.T) {

--- a/testdata/list5.html
+++ b/testdata/list5.html
@@ -1,0 +1,1 @@
+<ol><li>Something</li><li>Something else</li><li></li><li></li></ol><p><br></p>

--- a/testdata/list5.json
+++ b/testdata/list5.json
@@ -1,0 +1,23 @@
+[
+    {
+        "insert": "Something"
+    },
+    {
+        "attributes": {
+            "list": "ordered"
+        },
+        "insert": "\n"
+    },
+    {
+        "insert": "Something else"
+    },
+    {
+        "attributes": {
+            "list": "ordered"
+        },
+        "insert": "\n\n\n"
+    },
+    {
+        "insert": "\n"
+    }
+]

--- a/testdata/list6.html
+++ b/testdata/list6.html
@@ -1,0 +1,1 @@
+<ol><li>Something</li><li><br></li></ol><p><br></p>

--- a/testdata/list6.json
+++ b/testdata/list6.json
@@ -1,0 +1,14 @@
+[
+    {
+        "insert": "Something"
+    },
+    {
+        "attributes": {
+            "list": "ordered"
+        },
+        "insert": "\n\n"
+    },
+    {
+        "insert": "\n"
+    }
+]


### PR DESCRIPTION
This PR demonstrates a test failure when one makes a list with a single non-empty bullet, then multiple empty bullets. E.g.

- Something
-
-
-

```plaintext
--- FAIL: TestRender (0.00s)
    --- FAIL: TestRender/list6 (0.00s)
        render_test.go:109: bad rendering:
            wanted:
            <ol><li>Something</li><li><br></li></ol><p><br></p>

            got:
            <ol><li>Something</li><<ol>></<ol>></ol><p><br></p>
```
